### PR TITLE
Update control.ts to avoid logging to console with text resize logic

### DIFF
--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -1923,9 +1923,9 @@ export class Control implements IAnimatable, IFocusableControl {
                 this._rebuildLayout = false;
                 this._processMeasures(parentMeasure, context);
                 rebuildCount++;
-            } while (this._rebuildLayout && rebuildCount < 3);
+            } while (this._rebuildLayout && rebuildCount < 4);
 
-            if (rebuildCount >= 3) {
+            if (rebuildCount >= 4) {
                 Logger.Error(`Layout cycle detected in GUI (Control name=${this.name}, uniqueId=${this.uniqueId})`);
             }
 
@@ -2893,3 +2893,4 @@ export class Control implements IAnimatable, IFocusableControl {
     }
 }
 RegisterClass("BABYLON.GUI.Control", Control);
+


### PR DESCRIPTION
Control.ts expects less than 3 layouts to occur but textBlock.ts will layout 3 times when resizeToFit is true -- this is because isDirty is set to true causing a recreation of fontOffset (even if font offset has the proper height) and thus fontOffset.height is getting recalculated to the old value.  We should fix the logic so that fontOffset retains the updated height value. Until then, upping the layout cycle detection error threshold